### PR TITLE
Modified setup process

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,1 @@
--r requirements.txt
-
-pytest
-twine>=1.11.0
-setuptools>=38.6.0
-wheel>=0.31.0
+.[dev]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-numpy
-cement
-pyyaml
-colorlog
-seaborn
-h5py
-pygpcca
-bionetgen>=0.7.5
-libroadrunner
-networkx
+.

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,25 @@ f = open("README.md", "r")
 LONG_DESCRIPTION = f.read()
 f.close()
 
+INSTALL_REQUIRES = [
+    "numpy",
+    "cement",
+    "pyyaml",
+    "colorlog",
+    "seaborn",
+    "h5py",
+    "pygpcca",
+    "bionetgen>=0.7.5",
+    "libroadrunner",
+    "networkx",
+]
+
+
+EXTRAS_REQUIRE = {
+    "dev" : ['pytest', 'twine>=1.11.0', 'setuptools>=38.6.0', 'wheel>=0.31.0']
+}
+
+
 setup(
     name="webng",
     version=VERSION,
@@ -34,6 +53,8 @@ setup(
     packages=find_packages(exclude=["ez_setup", "tests*"]),
     package_data={"webng": ["templates/*"]},
     include_package_data=True,
+    install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
     entry_points="""
         [console_scripts]
         webng = webng.main:main


### PR DESCRIPTION
Moved the requirements to setup.py without disrupting the old ways of installing (e.g. `pip install -r requirements.txt`). This will allow PyPi to actually parse the requirements and install the dependencies when `pip install webng` is called.

`pip install .` will install the normal with dependencies
`pip install .[dev]` will install the normal dependencies + extra 'dev' dependencies.
`pip install --no-deps .` will install `webng` without resolving any of the dependencies (exactly what it's doing right now).

From pypi:
`pip install webng[dev]` will install webng with dev from PyPI.

Not sure if this is wanted, but will make installation much easier for the regular user.