### PR TITLE
More Fixes to the installation process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+build-backend = 'setuptools.build_meta:__legacy__'
+# Minium 
+
+requires = [
+ 'setuptools>=38.6.0',
+ 'cement',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@ build-backend = 'setuptools.build_meta:__legacy__'
 requires = [
  'setuptools>=38.6.0',
  'cement',
+ 'pip',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ requires = [
  'setuptools>=38.6.0',
  'cement',
  'pip',
+ 'wheel',
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
 from webng.core.version import get_version
 
-
-
 VERSION = get_version()
 
 f = open("README.md", "r")
@@ -23,11 +21,9 @@ INSTALL_REQUIRES = [
     "westpa==2.0dev1"
 ]
 
-
 EXTRAS_REQUIRE = {
     "dev" : ['pytest', 'twine>=1.11.0', 'wheel>=0.31.0']
 }
-
 
 setup(
     name="webng",

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,6 @@
 from setuptools import setup, find_packages
 from webng.core.version import get_version
 
-# handle WESTPA version here for now
-import subprocess, sys
-
-subprocess.check_call(
-    [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "git+https://github.com/westpa/westpa.git@d9da04365ff645547fce9666e3483e2830550abd",
-    ]
-)
 
 
 VERSION = get_version()
@@ -32,11 +20,12 @@ INSTALL_REQUIRES = [
     "bionetgen>=0.7.5",
     "libroadrunner",
     "networkx",
+    "westpa==2.0dev1"
 ]
 
 
 EXTRAS_REQUIRE = {
-    "dev" : ['pytest', 'twine>=1.11.0', 'setuptools>=38.6.0', 'wheel>=0.31.0']
+    "dev" : ['pytest', 'twine>=1.11.0', 'wheel>=0.31.0']
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,20 @@
 from setuptools import setup, find_packages
 from webng.core.version import get_version
 
+# handle WESTPA version here for now
+import subprocess, sys
+
+subprocess.check_call(
+    [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "git+https://github.com/westpa/westpa.git@d9da04365ff645547fce9666e3483e2830550abd",
+    ]
+)
+
+
 VERSION = get_version()
 
 f = open("README.md", "r")
@@ -18,7 +32,6 @@ INSTALL_REQUIRES = [
     "bionetgen>=0.7.5",
     "libroadrunner",
     "networkx",
-    "westpa==2.0dev1"
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
The CI problem was before my changes in #3 and can be replicated by installing webng in a fresh install/conda environment. I fixed it by adding in setuptools, cement, pip, wheel into pyproject.toml so they are installed before webng is installed.

Once westpa 2022.01 is released, we can add westpa into the INSTALL_REQUIRES and remove the `subprocess from setup.py` and `pip from pyproject.toml`.

Example working CI here. https://github.com/jeremyleung521/webng/runs/7101707976?check_suite_focus=true

Re-enabling pip caching should speed things up.