### PR TITLE
Install westpa without using subprocess

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,5 @@ build-backend = 'setuptools.build_meta:__legacy__'
 requires = [
  'setuptools>=38.6.0',
  'cement',
- 'pip',
  'wheel',
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,6 @@
 from setuptools import setup, find_packages
 from webng.core.version import get_version
 
-# handle WESTPA version here for now
-import subprocess, sys
-
-subprocess.check_call(
-    [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "git+https://github.com/westpa/westpa.git@d9da04365ff645547fce9666e3483e2830550abd",
-    ]
-)
-
-
 VERSION = get_version()
 
 f = open("README.md", "r")
@@ -32,6 +18,7 @@ INSTALL_REQUIRES = [
     "bionetgen>=0.7.5",
     "libroadrunner",
     "networkx",
+    "westpa>=2022.01"
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
As I mentioned in #4, this removes the need to install westpa 2 via subprocess. Makes version controls much easier and more secure as it's pulled from pypi instead of a static git commit.